### PR TITLE
Feat: Input 컴포넌트 구현

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,3 +1,99 @@
-export default function Input() {
-	return <div>Input</div>;
+import { useState } from 'react';
+//눈 모양, 반응형
+type InputTypes = 'email' | 'username' | 'password';
+
+interface InputProps {
+	type: InputTypes;
+	onChange?: (value: string) => void;
+}
+interface PasswordCheckProps {
+	type: 'password-check';
+	password: string;
+	onChange?: (value: string) => void;
+}
+
+const cls = (...classnames: string[]) => {
+	return classnames.join(' ');
+};
+
+const types = {
+	email: {
+		htmlType: 'email',
+		label: '이메일',
+		regex: '^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$',
+		invalidMessage: '이메일 형식으로 작성해주세요',
+		placeholder: '이메일을 입력해주세요',
+	},
+	username: {
+		htmlType: 'text',
+		label: '닉네임',
+		regex: '^.{0,10}$',
+		invalidMessage: '10자 이하로 작성해주세요',
+		placeholder: '닉네임을 입력해주세요',
+	},
+	password: {
+		htmlType: 'password',
+		label: '비밀번호',
+		regex: '^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$',
+		invalidMessage: '영문자와 숫자를 포함한 8자 이상의 비밀번호를 입력하세요',
+		placeholder: '비밀번호를 입력해주세요',
+	},
+	'password-check': {
+		htmlType: 'password',
+		label: '비밀번호 확인',
+		regex: '',
+		invalidMessage: '비밀번호가 일치하지 않습니다',
+		placeholder: '비밀번호를 한 번 더 입력해주세요',
+	},
+};
+
+export default function Input({
+	type,
+	onChange = () => {},
+	...props
+}: InputProps | PasswordCheckProps) {
+	const { htmlType, label, regex, invalidMessage, placeholder } = types[type];
+	const [value, setValue] = useState('');
+
+	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setValue(event.target.value);
+		onChange(event.target.value);
+	};
+	const validateOnBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+		const isValid = event.target.validity.valid;
+		!isValid
+			? event.target.setAttribute('data-invalid', '')
+			: event.target.removeAttribute('data-invalid');
+	};
+	return (
+		<div className='flex flex-col items-start gap-2'>
+			{/* eslint-disable-next-line jsx-a11y/label-has-associated-control, jsx-a11y/label-has-for */}
+			<label htmlFor='email' className='text-base text-black2'>
+				{label}
+			</label>
+			<input
+				id={type}
+				type={htmlType}
+				value={value}
+				placeholder={placeholder}
+				onChange={handleChange}
+				onBlur={validateOnBlur}
+				required
+				pattern={
+					type !== 'password-check'
+						? regex
+						: `^${(props as PasswordCheckProps).password}$`
+				}
+				className={cls(
+					'peer flex flex-col items-center w-[52rem] h-[5rem] py-3 px-4 text-base',
+					type === 'password' ? 'text-black3' : 'text-black2',
+					'border-[1px] border-solid rounded-lg border-gray3 placeholder:text-gray4 focus:outline-none focus:border-purple data-[invalid]:border-red',
+				)}
+			></input>
+			<span className='hidden text-sm text-red peer-data-[invalid]:block'>
+				{invalidMessage}
+			</span>
+			<button></button>
+		</div>
+	);
 }

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,30 +1,9 @@
 import clsx from 'clsx';
-import { HTMLInputTypeAttribute, useState } from 'react';
+import { HTMLInputTypeAttribute, useId, useRef, useState } from 'react';
 
-type GeneralInputType =
-	| 'number'
-	| 'button'
-	| 'checkbox'
-	| 'color'
-	| 'date'
-	| 'datetime-local'
-	| 'file'
-	| 'hidden'
-	| 'image'
-	| 'month'
-	| 'radio'
-	| 'range'
-	| 'reset'
-	| 'search'
-	| 'submit'
-	| 'tel'
-	| 'text'
-	| 'time'
-	| 'url'
-	| 'week';
+type GeneralInputType = 'text' | 'number' | 'hidden' | 'search' | 'tel' | 'url';
 
 interface generalInputProps {
-	id: string;
 	type: GeneralInputType;
 	label?: string;
 	placeholder?: string;
@@ -33,7 +12,7 @@ interface generalInputProps {
 
 interface signInputProps extends Omit<generalInputProps, 'type'> {
 	type: Extract<HTMLInputTypeAttribute, 'text' | 'email' | 'password'>;
-	regex: string;
+	pattern: string;
 	invalidMessage: string;
 }
 
@@ -48,28 +27,26 @@ const addInvalidClass = (event: React.FocusEvent<HTMLInputElement>) => {
 
 export default function Input(props: InputProps) {
 	const {
-		id,
 		type,
 		label,
 		placeholder,
 		onChange,
-		regex,
+		pattern,
 		invalidMessage,
 		...rest
 	} = props as signInputProps;
-	// const { id, type, label, placeholder, onChange } = props;
-	// const { regex, invalidMessage } = props as signInputProps;
-	const [value, setValue] = useState('');
+	console.log(pattern);
+	const id = useId();
+	const inputRef = useRef<HTMLInputElement>(null);
 	const [htmlType, setHtmlType] = useState(type);
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-		setValue(event.target.value);
 		if (onChange) {
 			onChange(event.target.value);
 		}
 	};
 	const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-		if (regex) {
+		if (pattern) {
 			addInvalidClass(event);
 		}
 	};
@@ -89,14 +66,14 @@ export default function Input(props: InputProps) {
 			)}
 			<div className='relative w-[520px] sm:w-[351px]'>
 				<input
+					ref={inputRef}
 					id={id}
 					type={htmlType}
-					value={value}
 					placeholder={placeholder}
 					onChange={handleChange}
 					onBlur={handleBlur}
 					required
-					pattern={regex}
+					pattern={pattern}
 					className={clsx(
 						'peer flex h-[50px] w-full flex-col items-center px-4 py-3 text-base',
 						type === 'password' ? 'text-black3' : 'text-black2',

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -47,8 +47,18 @@ const addInvalidClass = (event: React.FocusEvent<HTMLInputElement>) => {
 };
 
 export default function Input(props: InputProps) {
-	const { id, type, label, placeholder, onChange } = props;
-	const { regex, invalidMessage } = props as signInputProps;
+	const {
+		id,
+		type,
+		label,
+		placeholder,
+		onChange,
+		regex,
+		invalidMessage,
+		...rest
+	} = props as signInputProps;
+	// const { id, type, label, placeholder, onChange } = props;
+	// const { regex, invalidMessage } = props as signInputProps;
 	const [value, setValue] = useState('');
 	const [htmlType, setHtmlType] = useState(type);
 
@@ -92,6 +102,7 @@ export default function Input(props: InputProps) {
 						type === 'password' ? 'text-black3' : 'text-black2',
 						'rounded-lg border-[1px] border-solid border-gray3 placeholder:text-gray4 focus:border-purple focus:outline-none data-[invalid]:border-red',
 					)}
+					{...rest}
 				/>
 				{type === 'password' && (
 					<button

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -18,28 +18,28 @@ const cls = (...classnames: string[]) => {
 
 const types = {
 	email: {
-		htmlType: 'email',
+		inputType: 'email',
 		label: '이메일',
 		regex: '^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$',
 		invalidMessage: '이메일 형식으로 작성해주세요',
 		placeholder: '이메일을 입력해주세요',
 	},
 	username: {
-		htmlType: 'text',
+		inputType: 'text',
 		label: '닉네임',
 		regex: '^.{0,10}$',
 		invalidMessage: '10자 이하로 작성해주세요',
 		placeholder: '닉네임을 입력해주세요',
 	},
 	password: {
-		htmlType: 'password',
+		inputType: 'password',
 		label: '비밀번호',
 		regex: '^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$',
 		invalidMessage: '영문자와 숫자를 포함한 8자 이상의 비밀번호를 입력하세요',
 		placeholder: '비밀번호를 입력해주세요',
 	},
 	'password-check': {
-		htmlType: 'password',
+		inputType: 'password',
 		label: '비밀번호 확인',
 		regex: '',
 		invalidMessage: '비밀번호가 일치하지 않습니다',
@@ -52,8 +52,9 @@ export default function Input({
 	onChange = () => {},
 	...props
 }: InputProps | PasswordCheckProps) {
-	const { htmlType, label, regex, invalidMessage, placeholder } = types[type];
+	const { inputType, label, regex, invalidMessage, placeholder } = types[type];
 	const [value, setValue] = useState('');
+	const [htmlType, setHtmlType] = useState(inputType);
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		setValue(event.target.value);
@@ -65,35 +66,52 @@ export default function Input({
 			? event.target.setAttribute('data-invalid', '')
 			: event.target.removeAttribute('data-invalid');
 	};
+
+	const togglePasswordTypeOnClick = () => {
+		setHtmlType((prev) => (prev === 'password' ? 'text' : 'password'));
+	};
+
 	return (
 		<div className='flex flex-col items-start gap-2'>
 			{/* eslint-disable-next-line jsx-a11y/label-has-associated-control, jsx-a11y/label-has-for */}
-			<label htmlFor='email' className='text-base text-black2'>
+			<label htmlFor={type} className='text-base text-black2'>
 				{label}
 			</label>
-			<input
-				id={type}
-				type={htmlType}
-				value={value}
-				placeholder={placeholder}
-				onChange={handleChange}
-				onBlur={validateOnBlur}
-				required
-				pattern={
-					type !== 'password-check'
-						? regex
-						: `^${(props as PasswordCheckProps).password}$`
-				}
-				className={cls(
-					'peer flex flex-col items-center w-[52rem] h-[5rem] py-3 px-4 text-base',
-					type === 'password' ? 'text-black3' : 'text-black2',
-					'border-[1px] border-solid rounded-lg border-gray3 placeholder:text-gray4 focus:outline-none focus:border-purple data-[invalid]:border-red',
+			<div className='relative w-[520px]'>
+				<input
+					id={type}
+					type={htmlType}
+					value={value}
+					placeholder={placeholder}
+					onChange={handleChange}
+					onBlur={validateOnBlur}
+					required
+					pattern={
+						type !== 'password-check'
+							? regex
+							: `^${(props as PasswordCheckProps).password}$`
+					}
+					className={cls(
+						'peer flex flex-col items-center w-full h-[50px] py-3 px-4 text-base',
+						type === 'password' ? 'text-black3' : 'text-black2',
+						'border-[1px] border-solid rounded-lg border-gray3 placeholder:text-gray4 focus:outline-none focus:border-purple data-[invalid]:border-red',
+					)}
+				/>
+				{(type === 'password' || type === 'password-check') && (
+					<button
+						onClick={togglePasswordTypeOnClick}
+						className={cls(
+							'absolute right-4 top-[13px] size-6 border-none',
+							htmlType === 'password'
+								? 'bg-[url("/icons/visibility_off.svg")]'
+								: 'bg-[url("/icons/visibility_on.svg")]',
+						)}
+					/>
 				)}
-			></input>
-			<span className='hidden text-sm text-red peer-data-[invalid]:block'>
-				{invalidMessage}
-			</span>
-			<button></button>
+				<span className='hidden text-sm text-red peer-data-[invalid]:block'>
+					{invalidMessage}
+				</span>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## 어떤 변경인지

- [x] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [ ] Refactor: 기능 변경 없이 코드 수정
- [ ] Style: 디자인
- [ ] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명
1. 기존에 type 받아서 types 객체에서 input attribute를 지정하는 방식에서 멘토님이랑 찬주님이 말씀하신대로  input attribute를 모두 상위에서 내리는 것으로 변경하였습니다.
2. type이 email, password 일 경우 반드시 input태그의 `id, label='라벨명' placeholder, pattern='pattern속성값'` 속성을 요구합니다. 추가로 에러메시지 렌더링에 사용할 `invalidMessage`를 요구하도록 하였습니다.
이 외의 타입에서는 자유롭게 사용할 수 있도록 하였습니다.
3. 리뷰 반영하였습니다. 비제어 컴포넌트로 변경하였습니다.

### 이슈 번호
https://github.com/codeit-fe2-2/taskify/issues/2

### 주요 변경 사항

### 어떻게 동작하는지
1. type이 password, email이 아닐 경우 일반적인 input으로 사용할 수 있습니다.
2. 로그인 폼의 input으로 사용할 때에는 `id`, `type`, `label`, `pattern = '유효성 검증에 사용할 정규식'`, `invalidMessage = '유효하지 않을 시 에러메시지` 를 넘겨야 합니다. 이외에 input value lifting에 사용할 onChange를 넘길 수 있습니다.
4. 비밀번호 확인은 비밀번호 인풋의 password를 올려와서 pattern에 넘겨야 합니다.
5.  
```js
email: {
  id: 'email',
  type: 'email',
  label: '이메일',
  regex: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$',
  placeholder: '이메일을 입력해주세요',
  onChange: (value: string) => {
  console.log(`email: ${value}`);
  },
  invalidMessage: '이메일 형식으로 작성해주세요',
},
```
props를 태그에 직접 전달하지 않고 위와 같이 객체로 만든 후 전달할 경우 `type:'email'`이 `string`으로 추론되어 타입 에러가 납니다. `as`로 타입 명시하거나 객체 생성 시 type을 명시해야 합니다.

**테스트 파일에 아래 코드 복사해서 확인하시면 됩니다**
```js
import { useState } from 'react';

import Input from '@/src/components/ui/Input';

export default function Page() {
	const [password, setPassword] = useState('');
	const InputProps = {
		general: {
			type: 'text',
			placeholder: '인풋입니다',
			onChange: (value: string) => {
				console.log(`general: ${value}`);
			},
			invalidMessage: '이메일 형식으로 작성해주세요',
		},
		email: {
			type: 'email',
			label: '이메일',
			pattern:
				'/^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i',
			placeholder: '이메일을 입력해주세요',
			onChange: (value: string) => {
				console.log(`email: ${value}`);
			},
			invalidMessage: '이메일 형식으로 작성해주세요',
		},
		username: {
			type: 'text' as const,
			label: '닉네임',
			pattern: '^.{0,10}$',
			invalidMessage: '10자 이하로 작성해주세요',
			placeholder: '닉네임을 입력해주세요',
		},
		password: {
			type: 'password' as const,
			label: '비밀번호',
			pattern: '^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$',
			invalidMessage: '영문자와 숫자를 포함한 8자 이상의 비밀번호를 입력하세요',
			placeholder: '비밀번호를 입력해주세요',
			onChange: (value: string) => {
				setPassword(value);
				console.log(`password: ${value}`);
			},
		},
		passwordCheck: {
			type: 'password' as const,
			label: '비밀번호 확인',
			pattern: `^${password}$`,
			invalidMessage: '비밀번호가 일치하지 않습니다',
			placeholder: '비밀번호를 한 번 더 입력해주세요',
			onChange: (value: string) => {
				console.log(`passwordCheck: ${value}`);
			},
		},
		passwordError: {
			type: 'password',
			label: '비밀번호',
			pattern: '^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$',
			invalidMessage: '영문자와 숫자를 포함한 8자 이상의 비밀번호를 입력하세요',
			placeholder: '비밀번호를 입력해주세요',
			onChange: (value: string) => {
				setPassword(value);
				console.log(`password: ${value}`);
			},
		},
		// // 타입에러 확인용 password와 email
		typeError: {
			type: 'password' as const,
			label: '타입에러',
			placeholder: '비밀번호를 한 번 더 입력해주세요',
		},
	};
	return (
		<>
			<Input
				type='text'
				placeholder='그냥 인풋입니다'
				onChange={(value: string) => {
					console.log(`general: ${value}`);
				}}
			/>
			<Input
				type='email'
				label='이메일'
				pattern='/^[a-zA-Z0-9._%+-]+@+[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/i'
				placeholder='이메일을 입력해주세요'
				onChange={(value: string) => {
					console.log(`email: ${value}`);
				}}
				invalidMessage='이메일 형식으로 작성해주세요'
			/>
			<Input {...InputProps.username} />
			<Input {...InputProps.password} />
			<Input {...InputProps.passwordCheck} />
			{/* 객체로 props 전달시 as 로 타입 명시하지 않을 경우 type: string으로 추론되어 에러가 납니다. as 로 타입 명시해야 합니다*/}
			{/* <Input {...InputProps.passwordError} /> */}
			{/* <Input {...InputProps.typeError} /> */}
		</>
	);
}
```

### To Reviewers