### PR TITLE
feat: 나의 대시보드 페이지 구현

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ export default function Home() {
 	const handleDarkModeClick = () => {
 		setTheme(theme === 'dark' ? 'light' : 'dark');
 	};
-	console.log(theme);
+
 	return (
 		<>
 			<LandingHeader theme={theme} />

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -1,5 +1,131 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
 import BasicLayout from '@/src/components/layout/BasicLayout';
+import IconButton from '@/src/components/ui/Button/IconButton';
+import { PAGE_ROUTES } from '@/src/constants/routes';
+import { useGetDashboardList } from '@/src/hooks/dashboard/useGetDashboardList';
 
 export default function MyDashboardPage() {
-	return <BasicLayout>나의 대시보드 페이지</BasicLayout>;
+	const [fetchMethod, setFetchMethod] = useState({
+		method: 'pagination',
+		cursorId: 0,
+		page: 1,
+		size: 5,
+	});
+	const { dashboardListInfo, execute: fetchDashboardList } =
+		useGetDashboardList(
+			fetchMethod.method as 'pagination',
+			fetchMethod.cursorId,
+			fetchMethod.page,
+			fetchMethod.size,
+			true,
+		);
+
+	const dashboardList = dashboardListInfo?.dashboards || [];
+
+	const isExistsNextPage =
+		fetchMethod.page * fetchMethod.size < (dashboardListInfo?.totalCount || 0);
+
+	console.log('dashboardListInfo', dashboardListInfo);
+
+	/**
+	 * size 갯수 1페이지와 나머지를 달라지게 해야 함?
+	 */
+	const handleClickNextPage = () => {
+		setFetchMethod((prevFetchMethod) => ({
+			...prevFetchMethod,
+			page: prevFetchMethod.page + 1,
+		}));
+	};
+
+	const handleClickPrevPage = () => {
+		setFetchMethod((prevFetchMethod) => ({
+			...prevFetchMethod,
+			page: prevFetchMethod.page - 1,
+		}));
+	};
+
+	useEffect(() => {
+		fetchDashboardList();
+	}, [fetchMethod]);
+
+	return (
+		<BasicLayout>
+			<div className='p-10 sm:p-6'>
+				<div className='max-w-[1022px]'>
+					<div className='grid  grid-cols-3 grid-rows-2 gap-3 sm:grid-cols-1 sm:grid-rows-6 md:grid-cols-2 md:grid-rows-3'>
+						<button className='flex items-center justify-center gap-3 rounded-lg border border-solid border-gray3 bg-white py-6'>
+							<span className='font-semibold'>새로운 대시보드</span>
+							<Image
+								src={'/icons/plus.svg'}
+								alt='플러스'
+								width={22}
+								height={22}
+							/>
+						</button>
+						{dashboardList.map((dashboard) => (
+							<Link
+								key={dashboard.id}
+								href={PAGE_ROUTES.DASHBOARD + dashboard.id}
+								className='flex items-center justify-between rounded-lg border border-solid border-gray3 bg-white px-5'
+							>
+								<div className='flex items-center gap-4'>
+									<div
+										className={`size-[8px] rounded-full`}
+										style={{ backgroundColor: dashboard.color }}
+									></div>
+									<span className='font-semibold'>{dashboard.title}</span>
+									{dashboard.createdByMe && (
+										<Image
+											src={'/icons/crown.svg'}
+											alt='왕관'
+											width={20}
+											height={16}
+											className='md:h-[14px] md:w-[18px]'
+										/>
+									)}
+								</div>
+								<Image
+									src={'/icons/arrowNext.svg'}
+									alt='화살표'
+									width={18}
+									height={18}
+								/>
+							</Link>
+						))}
+					</div>
+					<div className='mt-3 flex items-center justify-end gap-4'>
+						<span className='text-sm sm:text-xs'>
+							{Math.ceil(
+								(dashboardListInfo?.totalCount || 0) / fetchMethod.size,
+							)}{' '}
+							페이지 중 {fetchMethod.page}
+						</span>
+						<div>
+							<IconButton
+								src='/icons/arrowBefore.svg'
+								alt='plus'
+								iconSize={16}
+								buttonSize='xs'
+								rounded='left'
+								disabled={fetchMethod.page === 1 ? true : false}
+								onClick={handleClickPrevPage}
+							/>
+							<IconButton
+								src='/icons/arrowNext.svg'
+								alt='plus'
+								iconSize={16}
+								buttonSize='xs'
+								rounded='right'
+								disabled={!isExistsNextPage}
+								onClick={handleClickNextPage}
+							/>
+						</div>
+					</div>
+				</div>
+			</div>
+		</BasicLayout>
+	);
 }

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -28,8 +28,6 @@ export default function MyDashboardPage() {
 	const isExistsNextPage =
 		fetchMethod.page * fetchMethod.size < (dashboardListInfo?.totalCount || 0);
 
-	console.log('dashboardListInfo', dashboardListInfo);
-
 	/**
 	 * size 갯수 1페이지와 나머지를 달라지게 해야 함?
 	 */

--- a/src/components/layout/BasicLayout.tsx
+++ b/src/components/layout/BasicLayout.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 import Header from '@/src/components/layout/Header';
 import SideMenu from '@/src/components/layout/SideMenu';
@@ -10,7 +10,13 @@ export default function BaicLayout({ children }: { children: ReactNode }) {
 	const { boardid } = router.query;
 	const boardId = boardid ? parseInt(boardid as string) : 0;
 
-	const { dashboardListInfo, execute } = useGetDashboardList();
+	const { dashboardListInfo } = useGetDashboardList(
+		'pagination',
+		0,
+		1,
+		15,
+		false,
+	);
 	const dashboards = dashboardListInfo?.dashboards;
 	const cursorId = dashboardListInfo?.cursorId;
 	const currentDashboard = dashboards?.find(
@@ -26,7 +32,9 @@ export default function BaicLayout({ children }: { children: ReactNode }) {
 			/>
 			<div className='grow'>
 				<Header currentDashboard={currentDashboard} />
-				<main>{children}</main>
+				<main className='h-[calc(100vh-var(--header-height))] bg-gray1 sm:h-[calc(100vh-var(--header-height-sm))]'>
+					{children}
+				</main>
 			</div>
 		</div>
 	);

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,7 +19,7 @@ export default function Header({ currentDashboard, user }: Props) {
 	return (
 		<header
 			className={clsx(
-				'flex h-[70px] items-center justify-between border-b border-gray3 sm:h-[60px]',
+				'flex h-[var(--header-height)] items-center justify-between border-b border-gray3 sm:h-[var(--header-height-sm)]',
 				isDashboardPage && 'sm:justify-around md:justify-around',
 			)}
 		>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -35,7 +35,6 @@ export default function Input(props: InputProps) {
 		invalidMessage,
 		...rest
 	} = props as signInputProps;
-	console.log(pattern);
 	const id = useId();
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [htmlType, setHtmlType] = useState(type);

--- a/src/hooks/dashboard/useGetDashboardList.ts
+++ b/src/hooks/dashboard/useGetDashboardList.ts
@@ -2,12 +2,18 @@ import axiosInstance from '@/src/apis/axiosInstance';
 import { useAsync } from '@/src/hooks/useAsync';
 import { DashboardListGetResponse } from '@/src/types/dashboard';
 
-export const useGetDashboardList = () => {
+export const useGetDashboardList = (
+	method: 'pagination' | 'infiniteScroll',
+	cursorId: number,
+	page: number,
+	size: number,
+	lazy: boolean,
+) => {
 	const getDashboards = () =>
 		axiosInstance.get<DashboardListGetResponse>(
-			'/dashboards?navigationMethod=infiniteScroll&size=100',
+			`/dashboards?navigationMethod=${method}&cursorId=${cursorId}&page=${page}&size=${size}`,
 		);
-	const { data, execute } = useAsync(getDashboards);
+	const { data, execute } = useAsync(getDashboards, lazy);
 
 	return { dashboardListInfo: data, execute };
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -7,6 +7,8 @@
 	--foreground-rgb: 0, 0, 0;
 	--background-start-rgb: 214, 219, 220;
 	--background-end-rgb: 255, 255, 255;
+	--header-height: 70px;
+	--header-height-sm: 60px;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## 어떤 변경인지

- [x] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [ ] Refactor: 기능 변경 없이 코드 수정
- [ ] Style: 디자인
- [ ] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명

나의 대시보드 페이지의 대시보드 목록까지 구현했습니다.
현재 같은 api를 두 번 요청하는 방식으로 비효율적으로 구현되어 있으며 최적화 여지가 많습니다.
일단 버튼 등의 공통 컴포넌트도 사용하지 않았습니다. 추후 반영하겠습니다.
코드 베이스에 있는 모든 console.log도 삭제했습니다.

### 이슈 번호
> https://github.com/codeit-fe2-2/taskify/issues/40

### 주요 변경 사항
나의 대시보드 페이지에서 BasicLayout을 사용해 대시보드 목록을 불러오는 것 까지 구현했습니다.

### 어떻게 동작하는지
useGetDashboardList 훅을 lazy 하게? 사용해 필요할 때 fetching 하도록 구성했습니다.
여러 최적화 여지는 많이 남아있습니다.