### PR TITLE
Feature: 모달 시스템 및 공통 모달 구현

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { ThemeProvider } from 'next-themes';
 
+import { ModalProvider } from '@/src/contexts/ModalProvider';
 import { fontPretendard } from '@/styles/fonts';
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -13,9 +14,11 @@ export default function App({ Component, pageProps }: AppProps) {
 				<title>Taskify</title>
 			</Head>
 			<ThemeProvider attribute='class'>
-				<div className={fontPretendard.className}>
-					<Component {...pageProps} />
-				</div>
+				<ModalProvider>
+					<div className={fontPretendard.className}>
+						<Component {...pageProps} />
+					</div>
+				</ModalProvider>
 			</ThemeProvider>
 		</>
 	);

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,3 +1,0 @@
-export default function Modal() {
-	return <div>Modal</div>;
-}

--- a/src/components/ui/Modal/ConfirmModal.tsx
+++ b/src/components/ui/Modal/ConfirmModal.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from 'react';
+
+import TextButton from '@/src/components/ui/Button/TextButton';
+
+export default function ConfirmModal({
+	children,
+	cancelText = '취소',
+	cancelClick,
+	confirmText = '확인',
+	confirmClick,
+	classNames,
+}: {
+	children: ReactNode;
+	cancelText: string;
+	cancelClick: () => void;
+	confirmText: string;
+	confirmClick: () => void;
+	classNames: string;
+}) {
+	return (
+		<div className={`flex flex-col justify-between p-7 ${classNames}`}>
+			{children}
+			<div className='flex justify-end gap-3 sm:mt-9 sm:justify-center'>
+				<TextButton
+					buttonSize='md'
+					textSize='md'
+					color='secondary'
+					className=''
+					onClick={cancelClick}
+				>
+					{cancelText}
+				</TextButton>
+				<TextButton
+					buttonSize='md'
+					textSize='md'
+					color='primary'
+					className=''
+					onClick={confirmClick}
+				>
+					{confirmText}
+				</TextButton>
+			</div>
+		</div>
+	);
+}

--- a/src/components/ui/Modal/ContextModal.tsx
+++ b/src/components/ui/Modal/ContextModal.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+
+import TextButton from '@/src/components/ui/Button/TextButton';
+
+export default function ContextModal({
+	children,
+	buttonText,
+	buttonClick,
+}: {
+	children: ReactNode;
+	buttonText: string;
+	buttonClick: () => void;
+}) {
+	return (
+		<div className='h-[250px] w-[540px] p-7 sm:h-[220px] sm:w-[327px]'>
+			<span className='mt-[80px] flex justify-center text-lg font-medium sm:mt-[53px] sm:text-base'>
+				{children}
+			</span>
+			<div className='mt-8 flex justify-end sm:mt-9 sm:justify-center'>
+				<TextButton
+					buttonSize='md'
+					textSize='md'
+					color='primary'
+					className=''
+					onClick={buttonClick}
+				>
+					{buttonText}
+				</TextButton>
+			</div>
+		</div>
+	);
+}

--- a/src/components/ui/ModalWrapper.tsx
+++ b/src/components/ui/ModalWrapper.tsx
@@ -1,0 +1,49 @@
+import { ReactNode, useEffect, useRef } from 'react';
+
+interface Props {
+	id: string;
+	children: ReactNode;
+	onRemove: (id: string) => void;
+}
+
+function ModalWrapper({ children, id, onRemove }: Props) {
+	const ref = useRef<HTMLDialogElement>(null);
+
+	const handleClickOutside = (e: MouseEvent) => {
+		if (ref.current && ref.current === e.target) {
+			onRemove(id);
+		}
+	};
+
+	const handleKeydownEsc = (e: KeyboardEvent) => {
+		if (e.keyCode === 27) {
+			onRemove(id);
+		}
+	};
+
+	useEffect(() => {
+		if (ref.current) {
+			ref.current.showModal();
+			document.addEventListener('keydown', handleKeydownEsc);
+			document.addEventListener('click', handleClickOutside);
+			document.body.style.overflow = 'hidden';
+		}
+
+		return () => {
+			document.removeEventListener('keydown', handleKeydownEsc);
+			document.removeEventListener('click', handleClickOutside);
+			document.body.style.overflow = ' auto';
+			if (ref.current) {
+				ref.current.close();
+			}
+		};
+	}, [id]);
+
+	return (
+		<dialog ref={ref} className='rounded-lg'>
+			{children}
+		</dialog>
+	);
+}
+
+export default ModalWrapper;

--- a/src/contexts/ModalProvider.tsx
+++ b/src/contexts/ModalProvider.tsx
@@ -1,0 +1,61 @@
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+import Modal from '@/src/components/ui/ModalWrapper';
+
+type ModalType = {
+	id: string;
+	content: ReactNode;
+};
+
+interface ModalContextValue {
+	openModal: (content: ReactNode, id: string) => void;
+	closeModal: (id: string) => void;
+	closeAllModals: () => void;
+}
+
+const ModalContext = createContext<ModalContextValue>({
+	openModal: () => {},
+	closeModal: () => {},
+	closeAllModals: () => {},
+});
+
+export function ModalProvider({ children }: { children: ReactNode }) {
+	const [modals, setModals] = useState<ModalType[]>([]);
+
+	const openModal = (content: ReactNode, id: string) => {
+		const newModal = { id, content };
+		setModals((prevModals) => [...prevModals, newModal]);
+	};
+
+	const closeModal = (id: string) => {
+		setModals(
+			modals.filter((modal) => {
+				return modal.id !== id;
+			}),
+		);
+	};
+
+	const closeAllModals = () => {
+		setModals([]);
+	};
+
+	return (
+		<ModalContext.Provider value={{ openModal, closeModal, closeAllModals }}>
+			{modals.map((modal) => (
+				<Modal key={modal.id} id={modal.id} onRemove={closeModal}>
+					{modal.content}
+				</Modal>
+			))}
+			{children}
+		</ModalContext.Provider>
+	);
+}
+
+export function useModal() {
+	const context = useContext(ModalContext);
+	if (!context) {
+		throw new Error('반드시 ModalProvider 안에서 사용해야 합니다.');
+	}
+
+	return context;
+}


### PR DESCRIPTION
## 어떤 변경인지

- [x] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [ ] Refactor: 기능 변경 없이 코드 수정
- [ ] Style: 디자인
- [ ] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명

modal을 전역에서 관리할 수 있도록 컨텍스트를 만들었습니다.
dialog로 구현한 ModalWrapper의 children으로 사용할 모달 폼들을 주입받아 사용되도록 만들었습니다.
모달이 여러 개 열릴 상황을 고려하다보니 id 값을 주입 받아 사용하는 형식으로 만들었습니다. 다른 더 좋은 아이디어가 있다면 말씀해주세요.

ModalWrapper 는 기본적으로 외부 클릭, esc 클릭 시 모달이 닫히도록 구현돼 있습니다.
(그래서 제 모달을 이용하시려면 재환님 모달 스타일과 바깥 클릭 시 모달 닫히는 부분이 빠져야 할 것 같네요.. 😅)

시안을 분석해보니 단순 확인용 모달과 confirm 역할을 하는 모달 두 가지로 나누어져 있는 걸로 판단돼 ContextModal 과 ConfirmModal을 만들었습니다.
ContextModal 은 단순 메시지와 모달을 닫는 버튼이 있는 모달로 회원가입, 로그인 페이지에서 확인했고,
ConfirmModal은 여러 곳에서 사용되지만 내부 폼과 confirm 시 동작만 달라지기에 이렇게 두 가지로 추상화 해도 되겠다고 판단했습니다.
버튼이 없는 카드 상세 모달은 그냥 openModal 함수에 카드 컴포넌트와 id 를 넣으면 될 것 같습니다.

기능에 문제가 있거나 스타일이 이상하면 말씀해주세요. 수정하겠습니다!

### 이슈 번호

> https://github.com/codeit-fe2-2/taskify/issues/58

### 어떻게 동작하는지


```tsx
import BasicLayout from '@/src/components/layout/BasicLayout';
import Input from '@/src/components/ui/Input';
import ConfirmModal from '@/src/components/ui/Modal/ConfirmModal';
import ContextModal from '@/src/components/ui/Modal/ContextModal';
import { useModal } from '@/src/contexts/ModalProvider';

export default function MyDashboardPage() {
	const { openModal, closeModal } = useModal();
	const modalId = crypto.randomUUID();

	const handleClickOpenModal = () => {
		openModal(
			<ConfirmModal
				cancelText='취소'
				cancelClick={() => closeModal(modalId)}
				confirmText='변경'
				confirmClick={() => console.log('변경 로직')}
				classNames='h-[276px] w-[540px]'
			>
				<div>
					<span>컬럼 관리</span>
					<Input type='text' label='이름' />
				</div>
			</ConfirmModal>,
			modalId,
		);

		openModal(
			<ContextModal buttonText='확인' buttonClick={() => closeModal(modalId)}>
				비밀번호가 일치하지 않습니다.
			</ContextModal>,
			modalId,
		);
	};
	return (
		<BasicLayout>
			<button className='bg-pink' onClick={handleClickOpenModal}>
				모달 얍
			</button>
		</BasicLayout>
	);
}
```

제가 테스트 한 페이지입니다.
useModal 훅에서 openModal과 closeModal 함수를 제공 받아
openModal 함수에는 사용하고자 하는 모달의 폼과 고유한 id를,
closeModal 함수에는 id를 매개변수로 해서 콜백으로 넘겨주시면 열고 닫을 수 있습니다.