### PR TITLE
Refactor: Input width 스타일, 기본 브라우저 메시지 제거 등 수정

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -7,11 +7,13 @@ interface generalInputProps {
 	type: GeneralInputType;
 	label?: string;
 	placeholder?: string;
+	className?: string;
 	onChange?: (value: string) => void;
 }
 
 interface signInputProps extends Omit<generalInputProps, 'type'> {
 	type: Extract<HTMLInputTypeAttribute, 'text' | 'email' | 'password'>;
+	name: 'email' | 'nickname' | 'password' | 'passwordCheck';
 	pattern: string;
 	invalidMessage: string;
 }
@@ -28,11 +30,13 @@ const addInvalidClass = (event: React.FocusEvent<HTMLInputElement>) => {
 export default function Input(props: InputProps) {
 	const {
 		type,
+		name,
 		label,
 		placeholder,
 		onChange,
 		pattern,
 		invalidMessage,
+		className,
 		...rest
 	} = props as signInputProps;
 	const id = useId();
@@ -56,32 +60,36 @@ export default function Input(props: InputProps) {
 	};
 
 	return (
-		<div className='flex flex-col items-start gap-2'>
+		<div className='flex w-full flex-col items-start gap-2'>
 			{/* eslint-disable-next-line jsx-a11y/label-has-associated-control, jsx-a11y/label-has-for */}
 			{label && (
-				<label htmlFor={id} className='text-base text-black2'>
+				<label htmlFor={id} className='text-black2 text-base'>
 					{label}
 				</label>
 			)}
-			<div className='relative w-[520px] sm:w-[351px]'>
+			<div className='relative w-full'>
 				<input
 					ref={inputRef}
 					id={id}
+					name={name}
 					type={htmlType}
 					placeholder={placeholder}
 					onChange={handleChange}
 					onBlur={handleBlur}
 					required
 					pattern={pattern}
+					onInvalid={(e) => e.preventDefault()}
 					className={clsx(
 						'peer flex h-[50px] w-full flex-col items-center px-4 py-3 text-base',
 						type === 'password' ? 'text-black3' : 'text-black2',
-						'rounded-lg border-[1px] border-solid border-gray3 placeholder:text-gray4 focus:border-purple focus:outline-none data-[invalid]:border-red',
+						'border-gray3 placeholder:text-gray4 focus:border-purple data-[invalid]:border-red rounded-lg border-[1px] border-solid focus:outline-none',
+						className,
 					)}
 					{...rest}
 				/>
 				{type === 'password' && (
 					<button
+						type='button'
 						onClick={togglePasswordTypeOnClick}
 						className={clsx(
 							'absolute right-4 top-[13px] size-6 border-none',
@@ -92,7 +100,7 @@ export default function Input(props: InputProps) {
 					/>
 				)}
 				{invalidMessage && (
-					<span className='hidden text-sm text-red peer-data-[invalid]:block'>
+					<span className='text-red hidden text-sm peer-data-[invalid]:block'>
 						{invalidMessage}
 					</span>
 				)}


### PR DESCRIPTION
## 어떤 변경인지
- [ ] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [x] Refactor: 기능 변경 없이 코드 수정
- [ ] Style: 디자인
- [ ] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명
input 기본 크기를 w-full, heigh 50px로 두고 외부에서 크기를 className으로 받아 쓰도록 변경
input에 onInvalid 핸들러 추가로 유효성 검증 통과 못할 시 브라우저의 기본 메시지 보이던 문제 없앰
type='button' 추가하여 enter 키 입력시 비밀번호 가림/보임이 동작하던 문제 없앰
name 속성 지정 추가
### 이슈 번호
.../codeit-fe2-2/taskify/issues/2

### 주요 변경 사항

### 어떻게 동작하는지

### To Reviewers
input 하나만 건드린 커밋이고 7줄 바뀐거라 확인 하신 분이 바로 머지 해주셔도 될 것 같습니다.
기존 인풋 만든 이슈번호 브랜치에 반영하고 싶어서 하다보니까 깃 헷갈리는 부분이 있어 좀 걸렸습니다 죄송합니다.
제가 폼 만들면서 건드렸던 것도 이번 커밋에 포함했습니다.
