### PR TITLE
feat : ProfileImage 없는 member의 경우 임시로 쓰기 좋은 DefaultProfileImage.tsx 작성

### DIFF
--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -3,10 +3,13 @@ import React from 'react';
 import DefaultProfileImage from '@/src/components/ui/DefaultProfileImage';
 
 export default function Page() {
-	const email = 'example@example.com';
+	const nickname = '각별님 너무 좋아';
 	return (
 		<div className='flex size-full flex-col gap-6 bg-violet2 p-1'>
-			<DefaultProfileImage email={email} classNames='size-[96px] text-[16px]' />
+			<DefaultProfileImage
+				nickname={nickname}
+				classNames='size-[96px] text-[16px]'
+			/>
 		</div>
 	);
 }

--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -1,19 +1,12 @@
 import React from 'react';
 
-import Card from '@/src/components/ui/Card';
-import Chips from '@/src/components/ui/Chips/Chips';
+import DefaultProfileImage from '@/src/components/ui/DefaultProfileImage';
 
 export default function Page() {
-	const handleValue = (value: string[]) => {
-		console.log(value[0]);
-	};
+	const email = 'example@example.com';
 	return (
-		<div className='flex flex-col gap-6 bg-gray2 p-1'>
-			<MemberTable />
-			<InvitelistTable />
-			<InvitedashTable />
-			<Chips />
-			<Card />
+		<div className='flex size-full flex-col gap-6 bg-violet2 p-1'>
+			<DefaultProfileImage email={email} classNames='size-[96px] text-[16px]' />
 		</div>
 	);
 }

--- a/src/components/ui/DefaultProfileImage.tsx
+++ b/src/components/ui/DefaultProfileImage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface DefaultProfileImageProps {
+	email: string;
+	classNames: string;
+}
+
+export default function DefaultProfileImage({
+	email,
+	classNames, // 텍스트 사이즈와 div 크기는 쓸 때마다 직접 기입 할 것
+}: DefaultProfileImageProps): JSX.Element {
+	const randomColors = [
+		'bg-[#fcdB00]',
+		'bg-[#1c1917]',
+		'bg-[#a3c4a2]',
+		'bg-[#f4d7da]',
+		'bg-[#c4b1a2]',
+		'bg-[#d25b68]',
+		'bg-[#9dd7ed]',
+		'bg-[#fdd446]',
+		'bg-[#ffc85a]',
+		'bg-[#25e09a]',
+	];
+	const emailHash = email.length % randomColors.length;
+	return (
+		<>
+			<div
+				className={`${classNames} ${randomColors[emailHash]} flex items-center justify-center rounded-full bg-red font-semibold text-white outline outline-4 outline-offset-0 outline-white`}
+			>
+				<p>{email.charAt(0).toUpperCase()}</p>
+			</div>
+		</>
+	);
+}

--- a/src/components/ui/DefaultProfileImage.tsx
+++ b/src/components/ui/DefaultProfileImage.tsx
@@ -28,9 +28,6 @@ export default function DefaultProfileImage({
 			>
 				<p>{nickname.charAt(0).toUpperCase()}</p>
 			</div>
-			<p>
-				{nickname}, {nicknameHash}, {nickname.charCodeAt(0)}
-			</p>
 		</>
 	);
 }

--- a/src/components/ui/DefaultProfileImage.tsx
+++ b/src/components/ui/DefaultProfileImage.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 
 interface DefaultProfileImageProps {
-	email: string;
+	nickname: string;
 	classNames: string;
 }
 
 export default function DefaultProfileImage({
-	email,
+	nickname,
 	classNames, // 텍스트 사이즈와 div 크기는 쓸 때마다 직접 기입 할 것
 }: DefaultProfileImageProps): JSX.Element {
 	const randomColors = [
 		'bg-[#fcdB00]',
 		'bg-[#1c1917]',
 		'bg-[#a3c4a2]',
-		'bg-[#f4d7da]',
 		'bg-[#c4b1a2]',
 		'bg-[#d25b68]',
 		'bg-[#9dd7ed]',
@@ -21,14 +20,17 @@ export default function DefaultProfileImage({
 		'bg-[#ffc85a]',
 		'bg-[#25e09a]',
 	];
-	const emailHash = email.length % randomColors.length;
+	const nicknameHash = nickname.charCodeAt(0) % randomColors.length;
 	return (
 		<>
 			<div
-				className={`${classNames} ${randomColors[emailHash]} flex items-center justify-center rounded-full bg-red font-semibold text-white outline outline-4 outline-offset-0 outline-white`}
+				className={`${classNames} ${randomColors[nicknameHash]} flex items-center justify-center rounded-full bg-red font-semibold text-white outline outline-4 outline-offset-0 outline-white`}
 			>
-				<p>{email.charAt(0).toUpperCase()}</p>
+				<p>{nickname.charAt(0).toUpperCase()}</p>
 			</div>
+			<p>
+				{nickname}, {nicknameHash}, {nickname.charCodeAt(0)}
+			</p>
 		</>
 	);
 }


### PR DESCRIPTION
## 어떤 변경인지

- [x] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [ ] Refactor: 기능 변경 없이 코드 수정
- [ ] Style: 디자인
- [ ] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명
- 멤버 이미지 없어 생기는 모든 에러를 평정하러 온 디폴트 프로필 이미지
- 해당 컴포넌트의 사이즈와 텍스트 크기는 직접 기입하셔야 합니다
- 닉네임을 프롭으로 받습니다
- 닉네임 첫글자의 유니코드에 따라 색상이 랜덤으로 정해집니다

### 이슈 번호

> https://github.com/codeit-fe2-2/taskify/issues/75

### 주요 변경 사항
- 만들었습니다

### 어떻게 동작하는지
<img width="115" alt="image" src="https://github.com/codeit-fe2-2/taskify/assets/79896328/7fd4ee27-566c-44e3-9ed1-76e7c3a201d9">

```tsx
import DefaultProfileImage from '@/src/components/ui/DefaultProfileImage';

export default function Page() {
	const nickname = '각별님 너무 좋아';
	return (
		<div className='flex size-full flex-col gap-6 bg-violet2 p-1'>
			<DefaultProfileImage
				nickname={nickname}
				classNames='size-[96px] text-[16px]'
			/>
		</div>
	);
}
```

### To Reviewers
- 이제 다시 table이랑 모달 인풋 고치러 갑니당
- 맘에 드시면 바로 머지 해주세요
